### PR TITLE
std feature (by default) and compiling for no-std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,7 @@ license-file = "LICENSE.txt"
 repository = "https://github.com/myrrlyn/bitvec"
 
 [dependencies]
+
+[features]
+default = ["std"]
+std = []

--- a/src/bits.rs
+++ b/src/bits.rs
@@ -5,7 +5,7 @@ storage of a primitive, and is the constraint for the storage type of a
 `BitVec`.
 !*/
 
-use std::{
+use core::{
 	cmp::Eq,
 	convert::From,
 	default::Default,
@@ -80,7 +80,7 @@ pub trait Bits:
 	const MASK: u8 = Self::WIDTH - 1;
 
 	/// The maximum number of this type that can be held in a `BitVec`.
-	const MAX_ELT: usize = std::usize::MAX >> Self::BITS;
+	const MAX_ELT: usize = core::usize::MAX >> Self::BITS;
 
 	/// Set a specific bit in an element to a given value.
 	fn set(&mut self, place: u8, value: bool) {
@@ -114,7 +114,7 @@ pub trait Bits:
 	/// Joins a `usize` element cursor and `u8` bit cursor into a single
 	/// `usize` cursor.
 	fn join(elt: usize, bit: u8) -> usize {
-		assert!(elt <= std::usize::MAX >> Self::BITS, "Element count out of range!");
+		assert!(elt <= core::usize::MAX >> Self::BITS, "Element count out of range!");
 		assert!(bit <= Self::MASK, "Bit count out of range!");
 		(elt << Self::BITS) | bit as usize
 	}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,9 @@ iteration in both directions, bit shifts, and, of course, access to the
 underlying storage as a slice.
 !*/
 
+#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(not(feature = "std"), feature(alloc))]
+
 #[macro_use]
 mod macros;
 
@@ -40,6 +43,12 @@ mod bits;
 mod endian;
 mod slice;
 mod vec;
+
+#[cfg(feature = "std")]
+extern crate core;
+
+#[cfg(not(feature = "std"))]
+extern crate alloc;
 
 pub use crate::{
 	bits::Bits,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -89,7 +89,7 @@ macro_rules! bitvec {
 	}};
 
 	( __bv_impl__ $endian:ident , $bits:ty ; $element:expr; $rep:expr ) => {{
-		std::iter::repeat( $element as u8 > 0 )
+		core::iter::repeat( $element as u8 > 0 )
 			.take( $rep )
 			.collect ::< $crate :: BitVec < $endian , $bits > > ()
 	}};
@@ -99,20 +99,20 @@ macro_rules! bitvec {
 macro_rules! __bitslice_shift {
 	( $( $t:ty ),+ ) => { $(
 		#[doc(hidden)]
-		impl<E: $crate :: Endian, T: $crate :: Bits> std::ops::ShlAssign< $t >
+		impl<E: $crate :: Endian, T: $crate :: Bits> core::ops::ShlAssign< $t >
 		for crate::BitSlice<E, T>
 		{
 			fn shl_assign(&mut self, shamt: $t ) {
-				std::ops::ShlAssign::<usize>::shl_assign(self, shamt as usize);
+				core::ops::ShlAssign::<usize>::shl_assign(self, shamt as usize);
 			}
 		}
 
 		#[doc(hidden)]
-		impl<E: $crate :: Endian, T: $crate :: Bits> std::ops::ShrAssign< $t >
+		impl<E: $crate :: Endian, T: $crate :: Bits> core::ops::ShrAssign< $t >
 		for crate::BitSlice<E, T>
 		{
 			fn shr_assign(&mut self, shamt: $t ) {
-				std::ops::ShrAssign::<usize>::shr_assign(self, shamt as usize);
+				core::ops::ShrAssign::<usize>::shr_assign(self, shamt as usize);
 			}
 		}
 	)+ };
@@ -122,42 +122,42 @@ macro_rules! __bitslice_shift {
 macro_rules! __bitvec_shift {
 	( $( $t:ty ),+ ) => { $(
 		#[doc(hidden)]
-		impl<E: $crate :: Endian, T: $crate :: Bits> std::ops::Shl< $t >
+		impl<E: $crate :: Endian, T: $crate :: Bits> core::ops::Shl< $t >
 		for $crate :: BitVec<E, T>
 		{
-			type Output = <Self as std::ops::Shl<usize>>::Output;
+			type Output = <Self as core::ops::Shl<usize>>::Output;
 
 			fn shl(self, shamt: $t ) -> Self::Output {
-				std::ops::Shl::<usize>::shl(self, shamt as usize)
+				core::ops::Shl::<usize>::shl(self, shamt as usize)
 			}
 		}
 
 		#[doc(hidden)]
-		impl<E: $crate :: Endian, T: $crate :: Bits> std::ops::ShlAssign< $t >
+		impl<E: $crate :: Endian, T: $crate :: Bits> core::ops::ShlAssign< $t >
 		for $crate :: BitVec<E, T>
 		{
 			fn shl_assign(&mut self, shamt: $t ) {
-				std::ops::ShlAssign::<usize>::shl_assign(self, shamt as usize)
+				core::ops::ShlAssign::<usize>::shl_assign(self, shamt as usize)
 			}
 		}
 
 		#[doc(hidden)]
-		impl<E: $crate :: Endian, T: $crate :: Bits> std::ops::Shr< $t >
+		impl<E: $crate :: Endian, T: $crate :: Bits> core::ops::Shr< $t >
 		for $crate :: BitVec<E, T>
 		{
-			type Output = <Self as std::ops::Shr<usize>>::Output;
+			type Output = <Self as core::ops::Shr<usize>>::Output;
 
 			fn shr(self, shamt: $t ) -> Self::Output {
-				std::ops::Shr::<usize>::shr(self, shamt as usize)
+				core::ops::Shr::<usize>::shr(self, shamt as usize)
 			}
 		}
 
 		#[doc(hidden)]
-		impl<E: $crate :: Endian, T: $crate :: Bits> std::ops::ShrAssign< $t >
+		impl<E: $crate :: Endian, T: $crate :: Bits> core::ops::ShrAssign< $t >
 		for $crate :: BitVec<E, T>
 		{
 			fn shr_assign(&mut self, shamt: $t ) {
-				std::ops::ShrAssign::<usize>::shr_assign(self, shamt as usize)
+				core::ops::ShrAssign::<usize>::shr_assign(self, shamt as usize)
 			}
 		}
 	)+ };

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -35,8 +35,7 @@ reference or mutable reference, and has the advantage that now it can be a
 count bits using `.into()`.
 !*/
 
-use std::{
-	borrow::ToOwned,
+use core::{
 	cmp::{
 		Eq,
 		Ord,
@@ -81,6 +80,12 @@ use std::{
 	ptr,
 	slice,
 };
+
+#[cfg(feature = "std")]
+use std::borrow::ToOwned;
+
+#[cfg(not(feature = "std"))]
+use alloc::borrow::ToOwned;
 
 /** A compact slice of bits, whose cursor and storage type can be customized.
 
@@ -556,7 +561,11 @@ where E: crate::Endian, T: crate::Bits {
 
 	/// Formats a partial element of the data slice.
 	pub(crate) fn fmt_bits(fmt: &mut Formatter, elt: &T, bits: u8) -> fmt::Result {
-		use std::fmt::Write;
+		use core::fmt::Write;
+
+		#[cfg(not(feature = "std"))]
+		use alloc::string::String;
+
 		let mut out = String::with_capacity(bits as usize);
 		for bit in 0 .. bits {
 			let cur = E::curr::<T>(bit);
@@ -927,7 +936,7 @@ where E: crate::Endian, T: crate::Bits {
 	/// assert_eq!(numr, &nums[2] as &BitSlice);
 	/// ```
 	fn add_assign(&mut self, addend: &'a BitSlice<E, T>) {
-		use std::iter::repeat;
+		use core::iter::repeat;
 		//  zero-extend the addend if it’s shorter than self
 		let mut addend_iter = addend.into_iter().rev().chain(repeat(false));
 		let mut c = false;
@@ -962,7 +971,7 @@ where E: crate::Endian, T: crate::Bits, I: IntoIterator<Item=bool> {
 	/// assert_eq!("000100", &format!("{}", lhs));
 	/// ```
 	fn bitand_assign(&mut self, rhs: I) {
-		use std::iter::repeat;
+		use core::iter::repeat;
 		for (idx, other) in (0 .. self.len()).zip(rhs.into_iter().chain(repeat(false))) {
 			let val = self.get(idx) & other;
 			self.set(idx, val);
@@ -1011,7 +1020,7 @@ where E: crate::Endian, T: crate::Bits, I: IntoIterator<Item=bool> {
 	/// assert_eq!("011001", &format!("{}", lhs));
 	/// ```
 	fn bitxor_assign(&mut self, rhs: I) {
-		use std::iter::repeat;
+		use core::iter::repeat;
 		for (idx, other) in (0 .. self.len()).zip(rhs.into_iter().chain(repeat(false))) {
 			let val = self.get(idx) ^ other;
 			self.set(idx, val);

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -7,7 +7,7 @@ The `BitSlice` module discusses the design decisions for the separation between
 slice and vector types.
 !*/
 
-use std::{
+use core::{
 	borrow::{
 		Borrow,
 		BorrowMut,
@@ -70,6 +70,12 @@ use std::{
 	},
 	ptr,
 };
+
+#[cfg(feature = "std")]
+use std::borrow::ToOwned;
+
+#[cfg(not(feature = "std"))]
+use alloc::{borrow::ToOwned, boxed::Box, vec::Vec};
 
 /** A compact `Vec` of bits, whose cursor and storage type can be customized.
 
@@ -174,7 +180,7 @@ where E: crate::Endian, T: crate::Bits {
 	/// assert!(bv[0]);
 	/// ```
 	pub fn push(&mut self, value: bool) {
-		assert!(self.len() < std::usize::MAX, "Vector will overflow!");
+		assert!(self.len() < core::usize::MAX, "Vector will overflow!");
 		let bit = self.bits();
 		//  Get a cursor to the bit that matches the semantic count.
 		let cursor = E::curr::<T>(bit);
@@ -1061,7 +1067,7 @@ where E: crate::Endian, T: crate::Bits {
 	/// assert_eq!(a, bitvec![1, 0, 0, 0, 0]);
 	/// ```
 	fn add_assign(&mut self, mut addend: Self) {
-		use std::iter::repeat;
+		use core::iter::repeat;
 		//  If the other vec is longer, swap them and try again.
 		if addend.len() > self.len() {
 			mem::swap(self, &mut addend);
@@ -1579,7 +1585,7 @@ where E: crate::Endian, T: crate::Bits {
 			let buf = self.as_mut();
 			let ptr = buf.as_mut_ptr();
 			let len = buf.len();
-			unsafe { std::ptr::write_bytes(ptr, 0, len); }
+			unsafe { core::ptr::write_bytes(ptr, 0, len); }
 			return;
 		}
 		for idx in shamt .. len {


### PR DESCRIPTION
Recently I wanted to use a bitvec in WASM in a project of mine. This PR adds an `std` feature which is enabled by default. When the feature is not enabled, the crate is compiled with `no-std` and draws on the `alloc` crate for certain types and traits. This means that compiling this crate for `no-std` currently requires a nightly compiler, although this is OK for my uses.

The API when compiling with `std` is backwards-compatible with the previous state.