### PR TITLE
Fix #[no_std] + #[feature(alloc)] support

### DIFF
--- a/src/vec.rs
+++ b/src/vec.rs
@@ -100,6 +100,7 @@ use core::{
 		self,
 		NonNull,
 	},
+    slice,
 };
 #[cfg(feature = "std")]
 use std::{
@@ -1164,7 +1165,7 @@ where C: Cursor, T: Bits {
 	pub fn set_elements(&mut self, element: T) {
 		self.do_unto_vec(|v| {
 			let (ptr, len) = (v.as_mut_ptr(), v.capacity());
-			for elt in unsafe { std::slice::from_raw_parts_mut(ptr, len) } {
+			for elt in unsafe { slice::from_raw_parts_mut(ptr, len) } {
 				*elt = element;
 			}
 		})


### PR DESCRIPTION
When building under `no_std` with `alloc`, there was an extraneous
usage of `std::slice` rather than `core::slice` which can be used
instead.