### PR TITLE
Add multiple platforms for bitvec CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,65 @@
 language: rust
 sudo: required
 cache: cargo
-rust:
-  - stable
-  - beta
-  - nightly
 
 matrix:
+  include:
+    - rust: stable
+      env: TARGET=x86_64-unknown-linux-gnu
+    - rust: beta
+      env: TARGET=x86_64-unknown-linux-gnu
+    - rust: nightly
+      env: TARGET=x86_64-unknown-linux-gnu
+
+    # Android
+    - env: TARGET=aarch64-linux-android DISABLE_TESTS=1
+    - env: TARGET=arm-linux-androideabi DISABLE_TESTS=1
+    - env: TARGET=armv7-linux-androideabi DISABLE_TESTS=1
+    - env: TARGET=i686-linux-android DISABLE_TESTS=1
+    - env: TARGET=x86_64-linux-android DISABLE_TESTS=1
+
+    # iOS
+    - env: TARGET=aarch64-apple-ios DISABLE_TESTS=1
+      os: osx
+    - env: TARGET=armv7-apple-ios DISABLE_TESTS=1
+      os: osx
+    - env: TARGET=armv7s-apple-ios DISABLE_TESTS=1
+      os: osx
+    - env: TARGET=i386-apple-ios DISABLE_TESTS=1
+      os: osx
+    - env: TARGET=x86_64-apple-ios DISABLE_TESTS=1
+      os: osx
+
+    # Linux
+    - env: TARGET=aarch64-unknown-linux-gnu
+    - env: TARGET=arm-unknown-linux-gnueabi
+    - env: TARGET=armv7-unknown-linux-gnueabihf
+    - env: TARGET=i686-unknown-linux-gnu
+    - env: TARGET=i686-unknown-linux-musl
+    - env: TARGET=mips-unknown-linux-gnu
+    - env: TARGET=mips64-unknown-linux-gnuabi64
+    - env: TARGET=mips64el-unknown-linux-gnuabi64
+    - env: TARGET=mipsel-unknown-linux-gnu
+    - env: TARGET=powerpc-unknown-linux-gnu
+    - env: TARGET=powerpc64-unknown-linux-gnu
+    - env: TARGET=powerpc64le-unknown-linux-gnu
+    - env: TARGET=s390x-unknown-linux-gnu DISABLE_TESTS=1
+    - env: TARGET=x86_64-unknown-linux-gnu
+    - env: TARGET=x86_64-unknown-linux-musl
+
+    # OSX
+    - env: TARGET=i686-apple-darwin
+      os: osx
+    - env: TARGET=x86_64-apple-darwin
+      os: osx
+
+    # *BSD
+    - env: TARGET=i686-unknown-freebsd DISABLE_TESTS=1
+    - env: TARGET=x86_64-unknown-freebsd DISABLE_TESTS=1
+    - env: TARGET=x86_64-unknown-netbsd DISABLE_TESTS=1
+
+    # Windows
+    - env: TARGET=x86_64-pc-windows-gnu
   allow_failures:
     - rust: nightly
 
@@ -25,17 +78,25 @@ addons:
       - libssl-dev
 
 before_cache: |
-  if [[ "$TRAVIS_RUST_VERSION" == stable ]]; then
+  if [[ "$TRAVIS_RUST_VERSION" = stable ]] && [[ "$TARGET" = x86_64-unknown-linux-gnu ]]; then
     cargo install cargo-tarpaulin -f
   fi
 
+before_install:
+  - set -e
+  - rustup self update
+
+install:
+  - sh ci/install_rust.sh
+  - source ~/.cargo/env || true
+
 script:
-- cargo clean
-- cargo build --all-features
-- cargo test --all-features
+  - cross clean
+  - cross build --target $TARGET --all-features
+  - if [ -z $DISABLE_TESTS ]; then cross test --target $TARGET --all-features ; fi
 
 after_success: |
-  if [[ "$TRAVIS_RUST_VERSION" == stable ]]; then
+  if [[ "$TRAVIS_RUST_VERSION" = stable ]] && [[ "$TARGET" = x86_64-unknown-linux-gnu ]]; then
     # Uncomment the following line for coveralls.io
     # cargo tarpaulin --ciserver travis-ci --coveralls $TRAVIS_JOB_ID
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,10 @@ cache: cargo
 
 matrix:
   include:
+    # Disable cross while building coverage, since cross interferes
+    # with caching and the current tarpaulin install.
     - rust: stable
-      env: TARGET=x86_64-unknown-linux-gnu
+      env: TARGET=x86_64-unknown-linux-gnu COVERAGE=1 DISABLE_CROSS=1
     - rust: beta
       env: TARGET=x86_64-unknown-linux-gnu
     - rust: nightly
@@ -52,7 +54,6 @@ matrix:
     - env: TARGET=powerpc64-unknown-linux-gnu
     - env: TARGET=powerpc64le-unknown-linux-gnu
     - env: TARGET=s390x-unknown-linux-gnu DISABLE_TESTS=1
-    - env: TARGET=x86_64-unknown-linux-gnu
     - env: TARGET=x86_64-unknown-linux-musl
 
     # OSX
@@ -77,31 +78,19 @@ addons:
     packages:
       - libssl-dev
 
-before_cache: |
-  if [[ "$TRAVIS_RUST_VERSION" = stable ]] && [[ "$TARGET" = x86_64-unknown-linux-gnu ]]; then
-    cargo install cargo-tarpaulin -f
-  fi
+before_cache:
+  - bash ci/install_taurpin.sh
 
 before_install:
   - set -e
   - rustup self update
 
 install:
-  - sh ci/install_rust.sh
+  - bash ci/install_rust.sh
   - source ~/.cargo/env || true
 
 script:
-  - cross clean
-  - cross build --target $TARGET --all-features
-  - if [ -z $DISABLE_TESTS ]; then cross test --target $TARGET --all-features ; fi
+  - bash ci/script.sh
 
-after_success: |
-  if [[ "$TRAVIS_RUST_VERSION" = stable ]] && [[ "$TARGET" = x86_64-unknown-linux-gnu ]]; then
-    # Uncomment the following line for coveralls.io
-    # cargo tarpaulin --ciserver travis-ci --coveralls $TRAVIS_JOB_ID
-
-    # Uncomment the following two lines create and upload a report for codecov.io
-    cargo tarpaulin --out Xml
-    bash <(curl -s https://codecov.io/bash)
-    echo "Uploaded code coverage"
-  fi
+after_success:
+  - bash ci/coverage.sh

--- a/ci/coverage.sh
+++ b/ci/coverage.sh
@@ -1,0 +1,9 @@
+if [[ ! -z $COVERAGE ]]; then
+    # Uncomment the following line for coveralls.io
+    # cargo tarpaulin --ciserver travis-ci --coveralls $TRAVIS_JOB_ID
+
+    # Uncomment the following two lines create and upload a report for codecov.io
+    cargo tarpaulin --out Xml
+    bash <(curl -s https://codecov.io/bash)
+    echo "Uploaded code coverage"
+fi

--- a/ci/install_rust.sh
+++ b/ci/install_rust.sh
@@ -1,0 +1,47 @@
+set -ex
+
+main() {
+    local target=
+    if [ $TRAVIS_OS_NAME = linux ]; then
+        target=x86_64-unknown-linux-musl
+        sort=sort
+    else
+        target=x86_64-apple-darwin
+        sort=gsort  # for `sort --sort-version`, from brew's coreutils.
+    fi
+
+    # Builds for iOS are done on OSX, but require the specific target to be
+    # installed.
+    case $TARGET in
+        aarch64-apple-ios)
+            rustup target install aarch64-apple-ios
+            ;;
+        armv7-apple-ios)
+            rustup target install armv7-apple-ios
+            ;;
+        armv7s-apple-ios)
+            rustup target install armv7s-apple-ios
+            ;;
+        i386-apple-ios)
+            rustup target install i386-apple-ios
+            ;;
+        x86_64-apple-ios)
+            rustup target install x86_64-apple-ios
+            ;;
+    esac
+
+    # This fetches latest stable release
+    local tag=$(git ls-remote --tags --refs --exit-code https://github.com/japaric/cross \
+                       | cut -d/ -f3 \
+                       | grep -E '^v[0.1.0-9.]+$' \
+                       | $sort --version-sort \
+                       | tail -n1)
+    curl -LSfs https://japaric.github.io/trust/install.sh | \
+        sh -s -- \
+           --force \
+           --git japaric/cross \
+           --tag $tag \
+           --target $target
+}
+
+main

--- a/ci/install_taurpin.sh
+++ b/ci/install_taurpin.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -ex
+
+if [[ ! -z $COVERAGE ]]; then
+    cargo install cargo-tarpaulin -f
+fi

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -ex
+
+# Detect our build command if we are on travis or not (so we can test locally).
+if [ -z $CI ] || [ ! -z $DISABLE_CROSS ]; then
+    # Not on CI or explicitly disabled cross, use cargo
+    CARGO=cargo
+else
+    # On CI, use cross.
+    CARGO=cross
+    CARGO_TARGET="--target $TARGET"
+fi
+
+$CARGO clean
+$CARGO build $CARGO_TARGET --all-features
+if [ -z $DISABLE_TESTS ]; then
+    $CARGO test $CARGO_TARGET --all-features
+fi


### PR DESCRIPTION
- Automatically build on numerous OSes, including Android, Windows GNU, iOS, Linux, and Mac OS X.
- Automatically build on numerous architectures, including PowerPC, MIPS, and many others.

Numerous difficult-to-detect bugs like #40 can occur in low-level crates making extensive use of platform-specific features, and therefore comprehensive testing using `cross` can help detect any commits that introduce platform-specific bugs.