### PR TITLE
Correctly produce `Domain::Enclave` at boundary condition

### DIFF
--- a/src/domain.rs
+++ b/src/domain.rs
@@ -470,7 +470,9 @@ where
 		match (*h, e, *t) {
 			//  Empty.
 			(_, 0, _) => Self::empty(),
-			//  Reaches both edges, for any number of elements.
+			//  Exactly consumes one element, touching both edges.
+			(0, 1, r) if r == w => Self::minor(h, elts, t),
+			//  Reaches both edges, for any number of elements greater than 1.
 			(0, _, t) if t == w => Self::spanning(elts),
 			//  Reaches only the tail edge, for any number of elements.
 			(_, _, t) if t == w => Self::partial_head(h, elts),

--- a/src/fields.rs
+++ b/src/fields.rs
@@ -1165,7 +1165,6 @@ mod tests {
 	}
 
 	#[test]
-	#[ignore] // failing
 	fn matched_slice() {
 		// This is a regression test to defend against a case where exact-size slices were produced
 		// as Domain::Region instead of Domain::Enclave.

--- a/src/fields.rs
+++ b/src/fields.rs
@@ -1163,6 +1163,19 @@ mod tests {
 		}
 		*/
 	}
+
+	#[test]
+	#[ignore] // failing
+	fn matched_slice() {
+		// This is a regression test to defend against a case where exact-size slices were produced
+		// as Domain::Region instead of Domain::Enclave.
+		let _: u64 = 0_usize.bits::<Lsb0>().load();
+		let _: u64 = 0_usize.bits::<Msb0>().load();
+		let _: u64 = 0_u64.bits::<Lsb0>().load();
+		let _: u64 = 0_u64.bits::<Msb0>().load();
+		let _: u64 = 0_u32.bits::<Lsb0>().load();
+		let _: u64 = 0_u32.bits::<Msb0>().load();
+	}
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Under certain circumstances when a `BitSlice` ran from `0..n` for `n` being the number of bits in the underlying `BitStore`, a `Domain::Region` was produced by `Domain::from(&BitSlice)` when a `Domain::Enclave` was warranted. This is the problem underlying #58, and the current pull request fixes #58.

Adding a specialization of the "Reaches both edges" case appears to be sufficient to resolve this issue.

The problem can be demonstrated by running `cargo test --lib -- --ignored` on the commit that introduces the test, before the fix is introduced one commit later.