### PR TITLE
Fix no_std with features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,9 @@ readme = "README.md"
 repository = "https://github.com/myrrlyn/bitvec"
 
 [features]
-alloc = []
+alloc = [
+    "wyz/alloc",
+]
 atomic = []
 default = [
 	"atomic",
@@ -47,9 +49,9 @@ std = [
 ]
 
 [dependencies]
-funty = "1"
+funty = { version = "1", default-features = false }
 radium = "0.3"
-wyz = "0.2"
+wyz = { version = "0.2", default-features = false }
 
 [dependencies.serde]
 default-features = false


### PR DESCRIPTION
Introducing wyz/funty caused no_std to fail, using them with features fixes it

Would you be interested in having a CI check for no_std? I could make a PR, something similar to this: https://github.com/sharksforarms/deku/tree/master/ensure_no_std

(That's how I found this failure)