### PR TITLE
Fix error in bitarr macro

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -219,7 +219,7 @@ macro_rules! bitarr {
 	};
 
 	(for $len:literal, in $store:ident) => {
-		$crate::bitarr!(for $len, in $crate::order::Lsb0, usize)
+		$crate::bitarr!(for $len, in $crate::order::Lsb0, $store)
 	};
 
 	(for $len:literal) => {


### PR DESCRIPTION
The macro receives a `$store` parameter, but `usize` was hardcoded in the code generation.

Also, please consider adding the `hacktoberfest-accepted` label to the pull request, as to contribute to my hacktoberfest progress. Thank you!