### PR TITLE
Fix `BitField::{store,load}_{le,be}` panic when the field is aligned to the storage boundary

### DIFF
--- a/src/field.rs
+++ b/src/field.rs
@@ -396,7 +396,11 @@ where T: BitStore
 
 				if let Some((head, elem)) = head {
 					let shamt = head.value();
-					accum <<= T::Mem::BITS - shamt;
+					if M::BITS > T::Mem::BITS - shamt {
+						accum <<= T::Mem::BITS - shamt;
+					} else {
+						accum = M::ZERO;
+					}
 					accum |= get::<T, M>(elem, Lsb0::mask(head, None), shamt);
 				}
 
@@ -429,9 +433,12 @@ where T: BitStore
 				}
 
 				if let Some((elem, tail)) = tail {
-					//  If the tail is at the limit, then none of the above
-					//  branches entered, and the shift would fail. Clamp to 0.
-					accum <<= tail.value() & M::MASK;
+					let shamt = tail.value();
+					if M::BITS > shamt {
+						accum <<= shamt;
+					} else {
+						accum = M::ZERO;
+					}
 					accum |= get::<T, M>(elem, Lsb0::mask(None, tail), 0);
 				}
 
@@ -452,7 +459,11 @@ where T: BitStore
 				if let Some((head, elem)) = head {
 					let shamt = head.value();
 					set::<T, M>(elem, value, Lsb0::mask(head, None), shamt);
-					value >>= T::Mem::BITS - shamt;
+					if M::BITS > T::Mem::BITS - shamt {
+						value >>= T::Mem::BITS - shamt;
+					} else {
+						value = M::ZERO;
+					}
 				}
 
 				for elem in body.iter_mut() {
@@ -480,9 +491,12 @@ where T: BitStore
 			DomainMut::Region { head, body, tail } => {
 				if let Some((elem, tail)) = tail {
 					set::<T, M>(elem, value, Lsb0::mask(None, tail), 0);
-					//  If the tail is at the limit, then none of the below
-					//  branches will enter, and the shift will fail. Clamp to 0
-					value >>= tail.value() & M::MASK;
+					let shamt = tail.value();
+					if M::BITS > shamt {
+						value >>= shamt;
+					} else {
+						value = M::ZERO;
+					}
 				}
 
 				for elem in body.iter_mut().rev() {
@@ -537,7 +551,12 @@ where T: BitStore
 				}
 
 				if let Some((head, elem)) = head {
-					accum <<= T::Mem::BITS - head.value();
+					let shamt = T::Mem::BITS - head.value();
+					if M::BITS > shamt {
+						accum <<= shamt;
+					} else {
+						accum = M::ZERO;
+					}
 					accum |= get::<T, M>(elem, Msb0::mask(head, None), 0);
 				}
 
@@ -571,12 +590,16 @@ where T: BitStore
 				}
 
 				if let Some((elem, tail)) = tail {
-					let width = tail.value();
-					accum <<= width;
+					let shamt = tail.value();
+					if M::BITS > shamt {
+						accum <<= shamt;
+					} else {
+						accum = M::ZERO;
+					}
 					accum |= get::<T, M>(
 						elem,
 						Msb0::mask(None, tail),
-						T::Mem::BITS - width,
+						T::Mem::BITS - shamt,
 					);
 				}
 
@@ -599,7 +622,12 @@ where T: BitStore
 			DomainMut::Region { head, body, tail } => {
 				if let Some((head, elem)) = head {
 					set::<T, M>(elem, value, Msb0::mask(head, None), 0);
-					value >>= T::Mem::BITS - head.value();
+					let shamt = T::Mem::BITS - head.value();
+					if M::BITS > shamt {
+						value >>= shamt;
+					} else {
+						value = M::ZERO;
+					}
 				}
 
 				for elem in body.iter_mut() {
@@ -640,7 +668,11 @@ where T: BitStore
 						Msb0::mask(None, tail),
 						T::Mem::BITS - tail.value(),
 					);
-					value >>= tail.value();
+					if M::BITS > tail.value() {
+						value >>= tail.value();
+					} else {
+						value = M::ZERO;
+					}
 				}
 
 				for elem in body.iter_mut().rev() {

--- a/src/field/tests.rs
+++ b/src/field/tests.rs
@@ -90,6 +90,65 @@ fn byte_fields() {
 }
 
 #[test]
+fn narrow_byte_fields() {
+	let mut data = [0u16; 2];
+
+	data.view_bits_mut::<Msb0>()[16..24].store_be(0x12u8);
+	assert_eq!(data, [0x0000, 0x1200]);
+	assert_eq!(data.view_bits::<Msb0>()[16..24].load_be::<u8>(), 0x12);
+
+	data.view_bits_mut::<Msb0>()[8..16].store_be(0x34u8);
+	assert_eq!(data, [0x0034, 0x1200]);
+	assert_eq!(data.view_bits::<Msb0>()[8..16].load_be::<u8>(), 0x34);
+
+	data.view_bits_mut::<Msb0>()[0..8].store_be(0x56u8);
+	assert_eq!(data, [0x5634, 0x1200]);
+	assert_eq!(data.view_bits::<Msb0>()[0..8].load_be::<u8>(), 0x56);
+
+	data = [0; 2];
+
+	data.view_bits_mut::<Msb0>()[16..24].store_le(0x12u8);
+	assert_eq!(data, [0x0000, 0x1200]);
+	assert_eq!(data.view_bits::<Msb0>()[16..24].load_le::<u8>(), 0x12);
+
+	data.view_bits_mut::<Msb0>()[8..16].store_le(0x34u8);
+	assert_eq!(data, [0x0034, 0x1200]);
+	assert_eq!(data.view_bits::<Msb0>()[8..16].load_le::<u8>(), 0x34);
+
+	data.view_bits_mut::<Msb0>()[0..8].store_le(0x56u8);
+	assert_eq!(data, [0x5634, 0x1200]);
+	assert_eq!(data.view_bits::<Msb0>()[0..8].load_le::<u8>(), 0x56);
+
+	data = [0; 2];
+
+	data.view_bits_mut::<Lsb0>()[16..24].store_be(0x12u8);
+	assert_eq!(data, [0x0000, 0x0012]);
+	assert_eq!(data.view_bits::<Lsb0>()[16..24].load_be::<u8>(), 0x12);
+
+	data.view_bits_mut::<Lsb0>()[8..16].store_be(0x34u8);
+	assert_eq!(data, [0x3400, 0x0012]);
+	assert_eq!(data.view_bits::<Lsb0>()[8..16].load_be::<u8>(), 0x34);
+
+	data.view_bits_mut::<Lsb0>()[0..8].store_be(0x56u8);
+	assert_eq!(data, [0x3456, 0x0012]);
+	assert_eq!(data.view_bits::<Lsb0>()[0..8].load_be::<u8>(), 0x56);
+
+	data = [0; 2];
+
+	data.view_bits_mut::<Lsb0>()[16..24].store_le(0x12u8);
+	assert_eq!(data, [0x0000, 0x0012]);
+	assert_eq!(data.view_bits::<Lsb0>()[16..24].load_le::<u8>(), 0x12);
+
+	data.view_bits_mut::<Lsb0>()[8..16].store_le(0x34u8);
+	assert_eq!(data, [0x3400, 0x0012]);
+	assert_eq!(data.view_bits::<Lsb0>()[8..16].load_le::<u8>(), 0x34);
+
+	data.view_bits_mut::<Lsb0>()[0..8].store_le(0x56u8);
+	assert_eq!(data, [0x3456, 0x0012]);
+	assert_eq!(data.view_bits::<Lsb0>()[0..8].load_le::<u8>(), 0x56);
+}
+
+#[test]
 fn wide_load() {
 	let mut data = bitarr![Lsb0, u16; 0; 256];
 	assert_eq!(data[16 .. 144].load::<u128>(), 0u128);


### PR DESCRIPTION
Both left and right shifts that are equal or exceed the value type bit
width panic.

`if/then/else` and `checked_sh[lr]().unwrap_or(0)` produce the same
[assembly when optimized][example].  (Switch to "Show Assembly" and look for functions `f` and `g`).

[example]: https://play.rust-lang.org/?version=stable&mode=release&edition=2018&gist=2a900f2862539a8f9b469f27b7082607