### PR TITLE
Bump radium version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ std = [
 ]
 
 [dependencies]
-radium = "0.6"
+radium = "0.6.1"
 tap = "1"
 
 [dependencies.funty]


### PR DESCRIPTION
Radium 0.6.1 supporst armv8m. Bump bitvec to use this version.